### PR TITLE
CRM-1235-DMS - After Signature/Logo is uploaded in Receipt Settings,page continues to display "No File Chosen"

### DIFF
--- a/templates/CRM/Cdntaxreceipts/Form/Settings.tpl
+++ b/templates/CRM/Cdntaxreceipts/Form/Settings.tpl
@@ -70,6 +70,7 @@
         <td class="label">{$form.receipt_logo.label}</td>
         <td class="content">{$form.receipt_logo.html}
           <p class="description">{ts domain='org.civicrm.cdntaxreceipts'}Logo size: 280x120 pixels; File types allowed: .jpg .png.{/ts}</p>
+          <img id="ReceiptLogoPreview" src="#" class="preview_image" alt="receipt_logo_preview" />
 	  {if $receipt_logo}
 	      {if $receipt_logo_class}<span class="crm-error">The file {$receipt_logo} was not found</span>
 	      {else}<p class="label">Current {$form.receipt_logo.label}: {$receipt_logo}</p>{/if}
@@ -79,6 +80,7 @@
         <td class="label">{$form.receipt_signature.label}</td>
         <td class="content">{$form.receipt_signature.html}
           <p class="description">{ts domain='org.civicrm.cdntaxreceipts'}Signature size: 141x58 pixels; File types allowed: .jpg .png.{/ts}</p>
+          <img id="ReceiptSignaturePreview" src="#" class="preview_image" alt="receipt_signatur_preview" />
 	  {if $receipt_signature}
 	      {if $receipt_signature_class}<span class="crm-error">The file {$receipt_signature} was not found</span>
 	      {else}<p class="label">Current {$form.receipt_signature.label}: {$receipt_signature}</p>{/if}


### PR DESCRIPTION
This code will implement preview of Tax receipt logo and Tax receipt signature images , when Admin uploads receipt  logo image or/and receipt signature image. On page load they can preview uploaded receipt logo or/and receipt signature image.