### PR TITLE
CRM-1595:DMS - Charity unable to issue Tax Receipts - Error stating ' From Email' not setup despite it being setup

### DIFF
--- a/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
+++ b/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
@@ -183,9 +183,10 @@ class CRM_Cdntaxreceipts_Form_ViewTaxReceipt extends CRM_Core_Form {
       $this->removeElement('from_email_address');
     }
     $from_email_address = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
-    $this->add('text', 'from_email_address', ts('From Email Address'), $from_email_address, TRUE);
-    $this->add('text', 'email_options', ts('Print and Email Options'), 'email', FALSE);
-    $this->add('text', 'group_by_separator', ts('Group By Seperator'), 'comma', FALSE);
+    //CRM-1596 "From Email Address" value being passed as attributes
+    $this->add('text', 'from_email_address', ts('From Email Address'), array('value' => $from_email_address), TRUE);
+    $this->add('text', 'email_options', ts('Print and Email Options'), array('value' => 'email'), FALSE);
+    $this->add('text', 'group_by_separator', ts('Group By Seperator'), array('value' => 'comma'), FALSE);
     $defaults = [
       'margin_left' => 0.75,
       'margin_right' => 0.75,

--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -329,9 +329,10 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
       $this->removeElement('from_email_address');
     }
     $from_email_address = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
-    $this->add('text', 'from_email_address', ts('From Email Address'), $from_email_address, TRUE);
-    $this->add('text', 'email_options', ts('Print and Email Options'), 'email', FALSE);
-    $this->add('text', 'group_by_separator', ts('Group By Seperator'), 'comma', FALSE);
+    //CRM-1596 "From Email Address" value being passed as attributes
+    $this->add('text', 'from_email_address', ts('From Email Address'), array('value' => $from_email_address), TRUE);
+    $this->add('text', 'email_options', ts('Print and Email Options'), array('value' => 'email'), FALSE);
+    $this->add('text', 'group_by_separator', ts('Group By Seperator'), array('value' => 'comma'), FALSE);
     $defaults = [
       'margin_left' => 0.75,
       'margin_right' => 0.75,

--- a/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
@@ -154,9 +154,10 @@ class CRM_Cdntaxreceipts_Task_IssueAnnualTaxReceipts extends CRM_Contact_Form_Ta
       $this->removeElement('from_email_address');
     }
     $from_email_address = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
-    $this->add('text', 'from_email_address', ts('From Email Address'), $from_email_address, TRUE);
-    $this->add('text', 'email_options', ts('Print and Email Options'), 'email', FALSE);
-    $this->add('text', 'group_by_separator', ts('Group By Seperator'), 'comma', FALSE);
+    //CRM-1596 "From Email Address" value being passed as attributes
+    $this->add('text', 'from_email_address', ts('From Email Address'), array('value' => $from_email_address), TRUE);
+    $this->add('text', 'email_options', ts('Print and Email Options'), array('value' => 'email'), FALSE);
+    $this->add('text', 'group_by_separator', ts('Group By Seperator'), array('value' => 'comma'), FALSE);
     $defaults = [
       'margin_left' => 0.75,
       'margin_right' => 0.75,

--- a/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
@@ -235,9 +235,10 @@ class CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts extends CRM_Contribute_Form
       $this->removeElement('from_email_address');
     }
     $from_email_address = current(CRM_Core_BAO_Domain::getNameAndEmail(FALSE, TRUE));
-    $this->add('text', 'from_email_address', ts('From Email Address'), $from_email_address, TRUE);
-    $this->add('text', 'email_options', ts('Print and Email Options'), 'email', FALSE);
-    $this->add('text', 'group_by_separator', ts('Group By Seperator'), 'comma', FALSE);
+    //CRM-1596 "From Email Address" value being passed as attributes
+    $this->add('text', 'from_email_address', ts('From Email Address'), array('value' => $from_email_address), TRUE);
+    $this->add('text', 'email_options', ts('Print and Email Options'), array('value' => 'email'), FALSE);
+    $this->add('text', 'group_by_separator', ts('Group By Seperator'), array('value' => 'comma'), FALSE);
     $defaults = [
       'margin_left' => 0.75,
       'margin_right' => 0.75,


### PR DESCRIPTION
 Rather than passing entire value as attribute, passed value in array as one of the attributes.