### PR TITLE
CRM-1168-Incorrect pop-up message appears when a tax receipt is issued after previewing it

### DIFF
--- a/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
@@ -395,11 +395,7 @@ class CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts extends CRM_Contribute_Form
     }
 
     // 3. Set session status
-    if ( $previewMode ) {
-      $status = ts('%1 tax receipt(s) have been previewed.  No receipts have been issued.', array(1=>$printCount, 'domain' => 'org.civicrm.cdntaxreceipts'));
-      CRM_Core_Session::setStatus($status, '', 'success');
-    }
-    else {
+    if(!$previewMode) {
       if ($emailCount > 0) {
         $status = ts('%1 tax receipt(s) were sent by email.', array(1=>$emailCount, 'domain' => 'org.civicrm.cdntaxreceipts'));
         CRM_Core_Session::setStatus($status, '', 'success');


### PR DESCRIPTION
From this code preview popup message will appear on button click, instead of page refresh. On click event sent jQuery ajax request is sent to  **CRM_Canadahelps_ExtensionUtils::singleTaxReceiptPreview** function to count number of tax receipts to be previewed and on success display result in popup message.