### PR TITLE
CRM-1610-CDN Tax Receipts - Email Single Receipt template needs to get updated - tokens not working

### DIFF
--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -2088,6 +2088,7 @@ function sendTemplate($params) {
     ],
     'contactId' => $params['contactId'] ?? NULL,
     'disableSmarty' => $params['disableSmarty'],
+    'tplParams' => $params['tplParams']
   ]);
 
   // send the template, honouring the target user’s preferences (if any)


### PR DESCRIPTION
We have passed one missing  parameter 'tplParams' to function which will convert token value properly.