### PR TITLE
CRM:1672: Merge Fields - Postal Greeting & Email Greeting - Fields not populating for issued Tax Receipts

### DIFF
--- a/CRM/Cdntaxreceipts/Task/PDFLetterCommon.php
+++ b/CRM/Cdntaxreceipts/Task/PDFLetterCommon.php
@@ -174,6 +174,8 @@ class CRM_Cdntaxreceipts_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFL
       $tokenHtml = CRM_Utils_Token::replaceContributionTokens($tokenHtml, $contribution, TRUE, $messageToken);
     }
     $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact, $categories, TRUE);
+    //CRM-1672 Added replaceGreetingTokens to successfully replace contact greeting tokens ('email_greeting','postal_greeting','addressee')
+    CRM_Utils_Token::replaceGreetingTokens($tokenHtml, $contact, $contact['contact_id']);
     if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
       $smarty = CRM_Core_Smarty::singleton();
       // also add the tokens to the template

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -1041,6 +1041,8 @@ function _receiptThankYouHeader($pdf, $pdf_variables, $receipt) {
     if(!empty($contactTokenValues)) {
       $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contactValues, $categories, TRUE);
     }
+    //CRM-1672 Added replaceGreetingTokens to successfully replace contact greeting tokens ('email_greeting','postal_greeting','addressee')
+    CRM_Utils_Token::replaceGreetingTokens($tokenHtml, $contact, $receipt['contact_id']);
   }
 
   //PDF Variables


### PR DESCRIPTION
Added **CRM_Utils_Token::replaceGreetingTokens();** function to successfully replace contact greeting tokens such as **'email_greeting','postal_greeting'** and **'addressee'** on a custom Thank You Message templates and on "CDN Tax Receipts - Thank you Note"