### PR TITLE
CRM-1724: Rename Task menu title on contribution tab

### DIFF
--- a/cdntaxreceipts.php
+++ b/cdntaxreceipts.php
@@ -401,13 +401,13 @@ function cdntaxreceipts_civicrm_searchTasks($objectType, &$tasks ) {
     }
     if (!$single_in_list) {
       $tasks[] = array (
-        'title' => ts('Issue Tax Receipts (Separate Receipt for Each Contribution)', array('domain' => 'org.civicrm.cdntaxreceipts')),
+        'title' => ts('Issue Separate Tax Receipts', array('domain' => 'org.civicrm.cdntaxreceipts')),
         'class' => 'CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts',
         'result' => TRUE);
     }
     if (!$aggregate_in_list) {
       $tasks[] = array (
-        'title' => ts('Issue Tax Receipts (Combined Receipt with Total Contributed)'),
+        'title' => ts('Issue Aggregated Tax Receipts'),
         'class' => 'CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts',
         'result' => TRUE);
     }


### PR DESCRIPTION
Renamed following task menu titles on contribution tab for CDNTaxreceipts

- Issue Tax Receipts (Combined Receipt with Total Contributed) => Issue Aggregated Tax Receipts
- Issue Tax Receipts  (Separate Receipt for Each  Contributed)=> Issue Separate Tax Receipts