### PR TITLE
CRM-1792:Merge Fields for different "Total Amounts" not working in receipt Thank You message

### DIFF
--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -470,6 +470,10 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
                   $data['values']['ViewTaxReceipt']['from_email_address'] = $from_email_address;
                   $data['values']['ViewTaxReceipt']['subject'] = $this->getElement('subject')->getValue();
                   $data['values']['ViewTaxReceipt']['html_message'] = $this->getElement('html_message')->getValue();
+                  //CRM-1792 Adding 'group_by' parameter for token processor to process grouped contributions
+                  if(count($contributions) > 1) {
+                    $params['group_by'] = 'contact_id';
+                  }
                   $thankyou_html = CRM_Cdntaxreceipts_Task_PDFLetterCommon::postProcessForm($this, $params);
                   if($thankyou_html) {
                     if(is_array($thankyou_html)) {

--- a/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
@@ -252,6 +252,11 @@ class CRM_Cdntaxreceipts_Task_IssueAnnualTaxReceipts extends CRM_Contact_Form_Ta
                   $data['values']['ViewTaxReceipt']['from_email_address'] = $from_email_address;
                   $data['values']['ViewTaxReceipt']['subject'] = $this->getElement('subject')->getValue();
                   $data['values']['ViewTaxReceipt']['html_message'] = $this->getElement('html_message')->getValue();
+                  //CRM-1792 Adding 'group_by' parameter for token processor to process grouped contributions
+                  if(count($contributions) > 1)
+                  {
+                    $params['group_by'] = 'contact_id';
+                  }
                   $thankyou_html = CRM_Cdntaxreceipts_Task_PDFLetterCommon::postProcessForm($this, $params);
                   if($thankyou_html) {
                     if(is_array($thankyou_html)) {

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -1035,28 +1035,23 @@ function _receiptThankYouHeader($pdf, $pdf_variables, $receipt) {
       'sequential' => 1,
       'id' => $receipt['contact_id'],
     ]);
-    $returnProperties = ['display_name'];
-    $contactTokenValues = CRM_Utils_Token::getTokenDetails(['contact_id' => $receipt['contact_id']],
-      $returnProperties,
-      true,
-      true,
-      NULL,
-      $messageToken
-    );
-    $contactValues = $contact['values'][0];
-    if(!empty($contactTokenValues)) {
-      $contactValues = array_merge($contactValues, $contactTokenValues[0][$receipt['contact_id']]);
+    
+    //CRM-1792 Replacing deprecated way of token processing with new token Processor
+    $groupedContributions = [];
+    $grouped = FALSE;
+    $realSeparator = ', ';
+    $separator = '****~~~~';
+    if(count($pdf_variables['receipt_contributions'])>1)
+    {
+      $grouped = TRUE;
+      foreach ($pdf_variables['receipt_contributions'] as $contriKey=>$contribution) {
+          $pdf_variables['receipt_contributions'][$contriKey]['id'] = $contribution['contribution_id'];
+        }
+      $groupedContributions = $pdf_variables['receipt_contributions'];
+    }else{
+      $contribution = $pdf_variables['receipt_contributions'][0]; 
     }
-    $categories = CRM_Cdntaxreceipts_Task_PDFLetterCommon::getTokenCategories();
-    $tokenHtml = CRM_Utils_Token::replaceContactTokens($newString, $contact, TRUE, $messageToken);
-    $domain = CRM_Core_BAO_Domain::getDomain();
-    $tokenHtml = CRM_Utils_Token::replaceDomainTokens($tokenHtml, $domain, TRUE, $messageToken);
-    $tokenHtml = CRM_Utils_Token::replaceContributionTokens($tokenHtml, $pdf_variables, TRUE, $messageToken);
-    if(!empty($contactTokenValues)) {
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contactValues, $categories, TRUE);
-    }
-    //CRM-1672 Added replaceGreetingTokens to successfully replace contact greeting tokens ('email_greeting','postal_greeting','addressee')
-    CRM_Utils_Token::replaceGreetingTokens($tokenHtml, $contact, $receipt['contact_id']);
+    $tokenHtml = str_replace($separator, $realSeparator, CRM_Cdntaxreceipts_Task_PDFLetterCommon::resolveTokens($newString, $contact, $contribution, $messageToken, $grouped, $separator, $groupedContributions));
   }
 
   //PDF Variables


### PR DESCRIPTION
**Root Cause**: CDNTaxReceipt module currently using the traditional way of token value processing by individually replacing token for contact, contribution, module, greetings and hook. Traditional contribution token processing is skipping all  "Total Amounts" related tokens.

**Solution**: Performed code refactoring and replaced traditional token replacement method to token processor for Thank you message template and custom template. Now "Total Amounts" related tokens are being processed successfully.

**Improvement**: Earlier when we issue aggregated tax receipt for multiple contributions at that time if we use contribution tokens in thank you message or custom template, we used to get value for only first contribution. For example if we are adding {contribution.total_amount} token in custom template for two contributions worth of $ 4 and $ 5, then ideal output should be $ 4, $ 5 in taxreceipt but right now its only considering first contribution of worth $ 4 only. With this improvement,
if one contact has multiple aggregated contributions then we are passing group_by value so contribution value can be grouped by contact_id and we receive combined tax receipt for all contributions. We have added additional logic to perform sum of all contribution values for {contribution.total_amount} token.