### PR TITLE
CRM-1868:DMS - Charity receiving Error when trying to Issue Tax Receipts in DMS

### DIFF
--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -1050,7 +1050,8 @@ function _receiptThankYouHeader($pdf, $pdf_variables, $receipt) {
 
   if($result['values'][0]) {
     $message_tpl = $result['values'][0];
-    $newString = $message_tpl['msg_html'] ?? NULL;
+    //CRM-1868 If "CDN Tax Receipts - Thank you Note" template is blank, assign string to $newString
+    $newString = $message_tpl['msg_html'] ?? '';
     $messageToken = CRM_Utils_Token::getTokens($newString);
     $contact =  civicrm_api3('Contact', 'get', [
       'sequential' => 1,


### PR DESCRIPTION
**Root Cause:** When "CDN Tax Receipts - Thank you Note" TemplateMessage is blank and NULL value was being assigned to $newString rather than String.

**Solution:** Assigned string value to $newString variable if "CDN Tax Receipts - Thank you Note" TemplateMessage is blank.