### PR TITLE
CRM-1918-Disable Receipts issuance if settings not validated

### DIFF
--- a/cdntaxreceipts.php
+++ b/cdntaxreceipts.php
@@ -336,6 +336,9 @@ function cdntaxreceipts_civicrm_searchTasks($objectType, &$tasks) {
       }
     }
     if (!$single_in_list) {
+      //CRM-1918-Disable 'Issue Separate Tax Receipts' action from contributions tab if receipts settings not validated
+      $receiptSettingValidateVal = Civi::settings()->get('settings_validated_taxreceipts');
+      if($receiptSettingValidateVal)
       $tasks[] = [
         'title' => E::ts('Issue Separate Tax Receipts'),
         'class' => 'CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts',
@@ -343,6 +346,9 @@ function cdntaxreceipts_civicrm_searchTasks($objectType, &$tasks) {
       ];
     }
     if (!$aggregate_in_list) {
+      //CRM-1918-Disable 'Issue Aggregated Tax Receipts' action from contributions tab if receipts settings not validated
+      $receiptSettingValidateVal = Civi::settings()->get('settings_validated_taxreceipts');
+      if($receiptSettingValidateVal)
       $tasks[] = [
         'title' => ts('Issue Aggregated Tax Receipts'),
         'class' => 'CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts',
@@ -358,6 +364,9 @@ function cdntaxreceipts_civicrm_searchTasks($objectType, &$tasks) {
       }
     }
     if (!$annual_in_list) {
+      //CRM-1918-Disable 'Issue Annual Tax Receipts' action from contacts tab if receipts settings not validated
+      $receiptSettingValidateVal = Civi::settings()->get('settings_validated_taxreceipts');
+      if($receiptSettingValidateVal)
       $tasks[] = [
         'title' => E::ts('Issue Annual Tax Receipts'),
         'class' => 'CRM_Cdntaxreceipts_Task_IssueAnnualTaxReceipts',


### PR DESCRIPTION
Used already existing function 'Civi::settings()->get('settings_validated_taxreceipts')' which is developed for CRM-1861 to check if receipt settings are correct or not. If not then disable the following actions.

(1)Disable the 'Issue Aggregated Tax Receipts' action from the contributions tab if receipts settings are not validated
(2)Disable the 'Issue Separate Tax Receipts' action from the contributions tab if receipts settings are not validated
(3)Disable the 'Issue Annual Tax Receipts' action from the contacts tab if receipts settings are not validated
