### PR TITLE
CRM-1959-'Issued On' value is not getting updated in 'Edit Contribution Form' if the contribution's tax receipt was replaced with a new one

### DIFF
--- a/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
+++ b/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
@@ -377,6 +377,12 @@ class CRM_Cdntaxreceipts_Form_ViewTaxReceipt extends CRM_Core_Form {
           //CRM-921: Mark Contribution as thanked if checked
           if($this->getElement('thankyou_date')->getValue()) {
             $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+          }
+          //CRM-1959
+          $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contributionId);
+          if($contributionReceiptDate && !empty($contributionReceiptDate))
+          {
+            $contribution->receipt_date = $contributionReceiptDate;
             $contribution->save();
           }
 

--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -319,17 +319,23 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
 
         if( $ret !== 0 ) {
           //CRM-920: Mark Contribution as thanked if checked
-          if($this->getElement('thankyou_date')->getValue()) {
+        
             foreach($contributions as $contributionIds) {
               $contribution = new CRM_Contribute_DAO_Contribution();
               $contribution->id = $contributionIds['contribution_id'];
               if ( ! $contribution->find( TRUE ) ) {
                 CRM_Core_Error::fatal( "CDNTaxReceipts: Could not find corresponding contribution id." );
               }
-              $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
-              $contribution->save();
+              if($this->getElement('thankyou_date')->getValue()) {
+                $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+                }
+                $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contribution->id);
+                if($contributionReceiptDate && !empty($contributionReceiptDate))
+                {
+                  $contribution->receipt_date = $contributionReceiptDate;
+                }
+                $contribution->save();
             }
-          }
         }
 
         if ( $ret == 0 ) {
@@ -369,6 +375,12 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
               //CRM-918: Mark Contribution as thanked if checked
               if($this->getElement('thankyou_date')->getValue()) {
                 $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+              }
+              //CRM-1959
+              $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contributionId);
+              if($contributionReceiptDate && !empty($contributionReceiptDate))
+              {
+                $contribution->receipt_date = $contributionReceiptDate;
                 $contribution->save();
               }
             }

--- a/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
@@ -274,18 +274,24 @@ class CRM_Cdntaxreceipts_Task_IssueAnnualTaxReceipts extends CRM_Contact_Form_Ta
 
         if( $ret !== 0 ) {
           //CRM-919: Mark Contribution as thanked if checked
-          if($this->getElement('thankyou_date')->getValue()) {
             foreach($contributions as $contributionIds) {
               $contribution = new CRM_Contribute_DAO_Contribution();
               $contribution->id = $contributionIds['contribution_id'];
               if ( ! $contribution->find( TRUE ) ) {
                 CRM_Core_Error::fatal( "CDNTaxReceipts: Could not find corresponding contribution id." );
               }
+              if($this->getElement('thankyou_date')->getValue()) {
               $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+              }
+              //CRM-1959
+              $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contribution->id);
+              if($contributionReceiptDate && !empty($contributionReceiptDate))
+              {
+                $contribution->receipt_date = $contributionReceiptDate;
+              }
               $contribution->save();
             }
           }
-        }
 
         if ( $ret == 0 ) {
           $failCount++;

--- a/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
@@ -247,6 +247,12 @@ class CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts extends CRM_Contribute_Form
             //CRM-918: Mark Contribution as thanked if checked
             if($this->getElement('thankyou_date')->getValue()) {
               $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+            }
+            //CRM-1959
+            $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contributionId);
+            if($contributionReceiptDate && !empty($contributionReceiptDate))
+            {
+              $contribution->receipt_date = $contributionReceiptDate;
               $contribution->save();
             }
           }

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -791,6 +791,25 @@ function cdntaxreceipts_configure_inkind_fields() {
 /**************************************
  * SECTION: Tax Receipt API
  */
+//CRM-1959 - 'Issued On' value is not getting updated in 'Edit Contribution Form' if the contribution's tax receipt was replaced with a new one
+function cdnaxreceipts_getReceiptDate($contributionID)
+{
+  $contributions = civicrm_api4('Contribution', 'get', [
+    'select' => [
+      'receipt_date',
+    ],
+    'where' => [
+      ['id', '=', $contributionID],
+    ],
+    'limit' => 1,
+  ]);
+  $contributionReceiptDate = 0 ;
+  foreach($contributions as $contribution)
+  {
+    $contributionReceiptDate = $contribution['receipt_date'];
+  }
+  return $contributionReceiptDate;
+}
 
 /**
  * issueTaxReceipt()


### PR DESCRIPTION
This is not the optimal way to update 'receipt_date' parameter for specific contributions. As CDNTaxreceipt modules require other sessions for code refactoring, at that time will include refactoring of this part of the code aswell.