### PR TITLE
Version 1.5.1.3

### DIFF
--- a/CRM/Cdntaxreceipts/Form/Settings.php
+++ b/CRM/Cdntaxreceipts/Form/Settings.php
@@ -90,14 +90,17 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
       'org_tel',
       'org_email',
       'org_web',
-      'org_charitable_no'];
+      'org_charitable_no',
+      'receipt_prefix'];
 
     foreach($receiptSettingsFields as $field) {
-      $value = trim($params[$field]);
+      //CRM-1972: Remove trim to get the original value of receipt_prefix field
+      $value = $params[$field];
       if (!isset($value))
         $value = '';
-
-      $isValid = CRM_Canadahelps_Config_Verify::isReceiptSettingsFieldValid($field, $value, TRUE);
+      //CRM-1972: Passing $required value as receipt_prefix is not mandatory field but if it has value then it should not contain any space.
+      $required = ($field == 'receipt_prefix') ? FALSE : TRUE;
+      $isValid = CRM_Canadahelps_Config_Verify::isReceiptSettingsFieldValid($field, $value, $required);
       if ( !$isValid || is_string($isValid))
         $errors[$field] = $isValid; // isReceiptSettingsFieldValid returns error if not valid
     }

--- a/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
+++ b/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
@@ -377,6 +377,12 @@ class CRM_Cdntaxreceipts_Form_ViewTaxReceipt extends CRM_Core_Form {
           //CRM-921: Mark Contribution as thanked if checked
           if($this->getElement('thankyou_date')->getValue()) {
             $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+          }
+          //CRM-1959
+          $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contributionId);
+          if($contributionReceiptDate && !empty($contributionReceiptDate))
+          {
+            $contribution->receipt_date = $contributionReceiptDate;
             $contribution->save();
           }
 

--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -317,17 +317,23 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
 
         if( $ret !== 0 ) {
           //CRM-920: Mark Contribution as thanked if checked
-          if($this->getElement('thankyou_date')->getValue()) {
+        
             foreach($contributions as $contributionIds) {
               $contribution = new CRM_Contribute_DAO_Contribution();
               $contribution->id = $contributionIds['contribution_id'];
               if ( ! $contribution->find( TRUE ) ) {
                 CRM_Core_Error::fatal( "CDNTaxReceipts: Could not find corresponding contribution id." );
               }
-              $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
-              $contribution->save();
+              if($this->getElement('thankyou_date')->getValue()) {
+                $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+                }
+                $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contribution->id);
+                if($contributionReceiptDate && !empty($contributionReceiptDate))
+                {
+                  $contribution->receipt_date = $contributionReceiptDate;
+                }
+                $contribution->save();
             }
-          }
         }
 
         if ( $ret == 0 ) {
@@ -367,6 +373,12 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
               //CRM-918: Mark Contribution as thanked if checked
               if($this->getElement('thankyou_date')->getValue()) {
                 $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+              }
+              //CRM-1959
+              $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contributionId);
+              if($contributionReceiptDate && !empty($contributionReceiptDate))
+              {
+                $contribution->receipt_date = $contributionReceiptDate;
                 $contribution->save();
               }
             }

--- a/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
@@ -274,18 +274,24 @@ class CRM_Cdntaxreceipts_Task_IssueAnnualTaxReceipts extends CRM_Contact_Form_Ta
 
         if( $ret !== 0 ) {
           //CRM-919: Mark Contribution as thanked if checked
-          if($this->getElement('thankyou_date')->getValue()) {
             foreach($contributions as $contributionIds) {
               $contribution = new CRM_Contribute_DAO_Contribution();
               $contribution->id = $contributionIds['contribution_id'];
               if ( ! $contribution->find( TRUE ) ) {
                 CRM_Core_Error::fatal( "CDNTaxReceipts: Could not find corresponding contribution id." );
               }
+              if($this->getElement('thankyou_date')->getValue()) {
               $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+              }
+              //CRM-1959
+              $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contribution->id);
+              if($contributionReceiptDate && !empty($contributionReceiptDate))
+              {
+                $contribution->receipt_date = $contributionReceiptDate;
+              }
               $contribution->save();
             }
           }
-        }
 
         if ( $ret == 0 ) {
           $failCount++;

--- a/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
@@ -247,6 +247,12 @@ class CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts extends CRM_Contribute_Form
             //CRM-918: Mark Contribution as thanked if checked
             if($this->getElement('thankyou_date')->getValue()) {
               $contribution->thankyou_date = date('Y-m-d H:i:s', CRM_Utils_Time::time());
+            }
+            //CRM-1959
+            $contributionReceiptDate = cdnaxreceipts_getReceiptDate($contributionId);
+            if($contributionReceiptDate && !empty($contributionReceiptDate))
+            {
+              $contribution->receipt_date = $contributionReceiptDate;
               $contribution->save();
             }
           }

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -192,7 +192,13 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
         $sendTemplateParams['thankyou_email'] = TRUE;
         $sendTemplateParams['html'] = $receipt['thankyou_html'];
       }
-      list($sent, $subject, $message, $html) = ch_sendTemplate($sendTemplateParams);
+      //CRM-1950 Duplicate receipt should not be sent to archive
+      if(($receipt['issue_method'] == 'email'|| $receipt['issue_method'] == 'print') && $receipt['is_duplicate'])
+      {
+        $sent = TRUE;
+      }else{
+        list($sent, $subject, $message, $html) = ch_sendTemplate($sendTemplateParams);
+      }
 
       // send a copy (with open tracking) to the donor
       if ($sent && $receipt['issue_method'] == 'email' && $mode != CDNTAXRECEIPTS_MODE_WORKFLOW) {
@@ -785,6 +791,25 @@ function cdntaxreceipts_configure_inkind_fields() {
 /**************************************
  * SECTION: Tax Receipt API
  */
+//CRM-1959 - 'Issued On' value is not getting updated in 'Edit Contribution Form' if the contribution's tax receipt was replaced with a new one
+function cdnaxreceipts_getReceiptDate($contributionID)
+{
+  $contributions = civicrm_api4('Contribution', 'get', [
+    'select' => [
+      'receipt_date',
+    ],
+    'where' => [
+      ['id', '=', $contributionID],
+    ],
+    'limit' => 1,
+  ]);
+  $contributionReceiptDate = 0 ;
+  foreach($contributions as $contribution)
+  {
+    $contributionReceiptDate = $contribution['receipt_date'];
+  }
+  return $contributionReceiptDate;
+}
 
 /**
  * issueTaxReceipt()

--- a/info.xml
+++ b/info.xml
@@ -10,8 +10,8 @@
   <maintainer>
     <author>CanadaHelps</author>
   </maintainer>
-  <releaseDate>2023-07-12</releaseDate>
-  <version>1.5.1.2</version>
+  <releaseDate>2023-07-25</releaseDate>
+  <version>1.5.1.3</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.49</ver>


### PR DESCRIPTION
Version 1.5.1.3

Requires v4.17.0+

CRA Compliance
- CRM-1950: Duplicate receipt should not be sent to archive
- CRM-1959: 'Issued On' value is not getting updated in 'Edit Contribution Form' if the contribution's tax receipt was replaced with a new one
- CRM-1966: Cancelled watermark added multiple times
- CRM-1972: Error appears while issuing a tax receipt if the Receipt Prefix has a space in it