### PR TITLE
CRM-1977-Replacing Aggregate Receipt

### DIFF
--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -74,7 +74,7 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
       if (is_array($status)) {
         $year = $status['receive_year'];
         // check if most recent is cancelled, and mark as "replace" then add that contribution to 'original' receipt array
-        $cancelledReceipt = CRM_Canadahelps_TaxReceipts_Receipt::receiptNumber($id, true);
+        $cancelledReceipt = CRM_Canadahelps_TaxReceipts_Receipt::retrieveReceiptDetails($id, true);
         $issue_type = (empty($status['receipt_id']) || ($cancelledReceipt[0] != NULL && $status['receipt_id'] == $cancelledReceipt[1])) ? 'original' : 'duplicate';
         $receipts[$issue_type][$year]['total_contrib']++;
         // Note: non-deductible amount has already had hook called in cdntaxreceipts_contributions_get_status
@@ -277,29 +277,17 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
           $contributions[$k]['receive_date'] = $contri['receive_date_original'];
         }
         //To Replace receipt we need to add extra parameters to contribution array
-        $cancelledReceipt = CRM_Canadahelps_TaxReceipts_Receipt::receiptNumber($contri['contribution_id'], true);
+        $cancelledReceipt = CRM_Canadahelps_TaxReceipts_Receipt::retrieveReceiptDetails($contri['contribution_id'], true);
         if ($cancelledReceipt[0] != NULL && $contri['receipt_id'] == $cancelledReceipt[1]) {
-          //CRM-1977 start
-          $existingReceipt = cdntaxreceipts_load_receipt($contri['receipt_id']);
-          if ($existingReceipt['receipt_status'] == 'cancelled' && $existingReceipt['issue_type'] == 'aggregate') {
-              $aggregatedReceiptContributionList = array_column($existingReceipt['contributions'],'contribution_id');
-              $originalContributionList = array_column($contributions,'contribution_id');
-              sort($originalContributionList);
-              sort($aggregatedReceiptContributionList);
-              if (empty(array_diff($aggregatedReceiptContributionList, $originalContributionList))) {
+          //CRM-1977
+              $cancelledReceiptContribIds = $cancelledReceipt[3];
+              $receiptContribIds = array_column($contributions,'contribution_id');
+              if (empty(array_diff($cancelledReceiptContribIds, $receiptContribIds))) {
                 $contributions[$k]['cancelled_replace_receipt_number']  = $cancelledReceipt[0];
-                $contributions[$k]['replace_receipt']  = 1;
-                $contributions[$k]['receipt_id']  = 0;
-              } else {
-                $contributions[$k]['replace_receipt']  = 1;
-                $contributions[$k]['receipt_id']  = 0;
-              }
-            }else{
-              $contributions[$k]['cancelled_replace_receipt_number']  = $cancelledReceipt[0];
+              } 
               $contributions[$k]['replace_receipt']  = 1;
               $contributions[$k]['receipt_id']  = 0;
             }
-        }
       }
       // $method = $contribution_status['issue_method'];
       $method = 'print';
@@ -378,7 +366,7 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
           list($issued_on, $receipt_id) = cdntaxreceipts_issued_on($contribution->id);
           //CRM-1990-Receipt not getting replaced for a cancelled In Kind donation through Aggregate Tax Receipt method
           // check if most recent is cancelled, and mark as "replace"
-          $cancelledInKindReceipt = CRM_Canadahelps_TaxReceipts_Receipt::receiptNumber($contribution->id, true);
+          $cancelledInKindReceipt = CRM_Canadahelps_TaxReceipts_Receipt::retrieveReceiptDetails($contribution->id, true);
           if ($cancelledInKindReceipt[0] != NULL && $receipt_id == $cancelledInKindReceipt[1]) {
             $contribution->cancelled_replace_receipt_number  = $cancelledInKindReceipt[0];
             $contribution->replace_receipt  = 1;

--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -279,9 +279,26 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
         //To Replace receipt we need to add extra parameters to contribution array
         $cancelledReceipt = CRM_Canadahelps_TaxReceipts_Receipt::receiptNumber($contri['contribution_id'], true);
         if ($cancelledReceipt[0] != NULL && $contri['receipt_id'] == $cancelledReceipt[1]) {
-          $contributions[$k]['cancelled_replace_receipt_number']  = $cancelledReceipt[0];
-          $contributions[$k]['replace_receipt']  = 1;
-          $contributions[$k]['receipt_id']  = 0;
+          //CRM-1977 start
+          $existingReceipt = cdntaxreceipts_load_receipt($contri['receipt_id']);
+          if ($existingReceipt['receipt_status'] == 'cancelled' && $existingReceipt['issue_type'] == 'aggregate') {
+              $aggregatedReceiptContributionList = array_column($existingReceipt['contributions'],'contribution_id');
+              $originalContributionList = array_column($contributions,'contribution_id');
+              sort($originalContributionList);
+              sort($aggregatedReceiptContributionList);
+              if (empty(array_diff($aggregatedReceiptContributionList, $originalContributionList))) {
+                $contributions[$k]['cancelled_replace_receipt_number']  = $cancelledReceipt[0];
+                $contributions[$k]['replace_receipt']  = 1;
+                $contributions[$k]['receipt_id']  = 0;
+              } else {
+                $contributions[$k]['replace_receipt']  = 1;
+                $contributions[$k]['receipt_id']  = 0;
+              }
+            }else{
+              $contributions[$k]['cancelled_replace_receipt_number']  = $cancelledReceipt[0];
+              $contributions[$k]['replace_receipt']  = 1;
+              $contributions[$k]['receipt_id']  = 0;
+            }
         }
       }
       // $method = $contribution_status['issue_method'];

--- a/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
@@ -228,7 +228,7 @@ class CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts extends CRM_Contribute_Form
         list($issued_on, $receipt_id) = cdntaxreceipts_issued_on($contribution->id);
 
         // check if most recent is cancelled, and mark as "replace"
-        $cancelledReceipt = CRM_Canadahelps_TaxReceipts_Receipt::receiptNumber($contribution->id, true);
+        $cancelledReceipt = CRM_Canadahelps_TaxReceipts_Receipt::retrieveReceiptDetails($contribution->id, true);
         if ($cancelledReceipt[0] != NULL && $receipt_id == $cancelledReceipt[1]) {
           $contribution->cancelled_replace_receipt_number  = $cancelledReceipt[0];
           $contribution->replace_receipt  = 1;

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -946,6 +946,8 @@ function cdntaxreceipts_issueTaxReceipt($contribution, &$collectedPdf = NULL, $m
 
   // CRM-1820 While replacing a receipt, passing receipt number
   if ($is_replaced) {
+    //CRM-1993 , CRM-1977 If we get cancelled receipt number value only
+    if($contribution->cancelled_replace_receipt_number)
     $receipt['cancelled_replace_receipt_number'] = $contribution->cancelled_replace_receipt_number;
     $receipt['is_replaced'] = 1;
   }
@@ -1317,8 +1319,9 @@ function cdntaxreceipts_issueAggregateTaxReceipt($contactId, $year, $contributio
   }
   // CRM-1820 While replacing a receipt, passing receipt number
   if ($is_replaced) {
-    $receipt['cancelled_replace_receipt_number'] = 
-    $cancelled_replace_receipt_number;
+     //CRM-1993 , CRM-1977 If we get cancelled receipt number value only
+    if($cancelled_replace_receipt_number)
+    $receipt['cancelled_replace_receipt_number'] = $cancelled_replace_receipt_number;
     $receipt['is_replaced'] = 1;
   }
 


### PR DESCRIPTION
For aggregated tax receipt

(1) When I select all of the same transactions on the original receipt, I see 'Cancels and Replaces' with the original tax receipt number on my re-issued tax receipt.

(2) When I have not selected the original transactions, but have selected a combination of the original transactions (it. 3 of 5), or some of the original transactions plus some new transactions, then I received a new tax receipt.

(3)if the aggregate receipt has only one contribution in that case for issuing separate or manage receipts, the 'cancel and replace receipt number' text should be visible.