### PR TITLE
CRM-1997-Getting an error while clicking the receipt number link in Contribution Details page

### DIFF
--- a/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
+++ b/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
@@ -26,6 +26,20 @@ class CRM_Cdntaxreceipts_Form_ViewTaxReceipt extends CRM_Core_Form {
     parent::preProcess();
     $contributionId = CRM_Utils_Array::value('id', $_GET);
     $contactId = CRM_Utils_Array::value('cid', $_GET);
+    //CRM-1997 when two contacts get merged, for contribution whose contact got merged to another contact was identifying old deleted contactID
+    if(CRM_Canadahelps_ExtensionUtils::isContactDeleted($contactId))
+    {
+      $contribution = civicrm_api4('Contribution', 'get', [
+        'select' => [
+          'contact_id',
+        ],
+        'where' => [
+          ['id', '=', $contributionId],
+        ],
+      ]);
+      if(isset($contribution[0]['contact_id']))
+      $contactId = $contribution[0]['contact_id'];
+    }
 
     if ( isset($contributionId) && isset($contactId) ) {
       $this->set('contribution_id', $contributionId);


### PR DESCRIPTION
when two contacts get merged, for contribution whose contact got merged to another contact identifies the old deleted contactID(based on cdntaxreceipts_log tabel) , so for that first code will check if the contact is deleted or not. If yes then based on the contribution ID will fetch and update the correct contact ID.