### PR TITLE
CRM-1977-1-Updated condition for 'cancelled_replace_receipt_number' for aggregated tax receipt

### DIFF
--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -282,7 +282,10 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
           //CRM-1977
               $cancelledReceiptContribIds = $cancelledReceipt[3];
               $receiptContribIds = array_column($contributions,'contribution_id');
-              if (empty(array_diff($cancelledReceiptContribIds, $receiptContribIds))) {
+              //CRM-1977-1-If Cancelled contribution Receipt List exactly matches with List of contributions List in that case only add 'cancelled_replace_receipt_number'
+              sort($receiptContribIds);
+              sort($cancelledReceiptContribIds);
+              if ($receiptContribIds === $cancelledReceiptContribIds){
                 $contributions[$k]['cancelled_replace_receipt_number']  = $cancelledReceipt[0];
               } 
               $contributions[$k]['replace_receipt']  = 1;


### PR DESCRIPTION
Updated condition for 'cancelled_replace_receipt_number' for aggregated tax receipt.

If the Cancelled contribution Receipt List exactly matches with the List of contributions List that case only add 'cancelled_replace_receipt_number'